### PR TITLE
Fix HTML tags in code blocks

### DIFF
--- a/less/tags.less
+++ b/less/tags.less
@@ -53,7 +53,7 @@
 }
 
 .category,
-.tag {
+a.tag {
   font-weight: 500;
   transition-property: color, background-color, outline-color, border-color, text-shadow;
   transition-duration: 0.2s;


### PR DESCRIPTION
We use the `tag` class name for links to blog post tags. It also ends up getting used when we syntax-highlight HTML, as you can see in [a blog post like this](https://blog.pulsar-edit.dev/posts/20231110-savetheclocktower-modern-tree-sitter-part-5/#a-mental-model-for-injections). Find one of the code blocks with HTML and notice how the padding on tag names is a big weird; then hover over a tag name and see how it incorrectly inherits the `:hover` styles of a blog post tag.

The easiest way to fix this is to be more specific when styling the blog post tags — since those class names will always be attached to anchor tags, we can target the tag name and avoid inadvertently styling HTML tags in code blocks.

In the general case, we could also probably solve this with some option in [Prism](https://prismjs.com/), but this is the quick fix.